### PR TITLE
Changing timestamp check of previous run to use local time instead of UTC

### DIFF
--- a/js/utilities.js
+++ b/js/utilities.js
@@ -89,7 +89,8 @@ async function _getLastUpdateTS(_config) {
         } //if
         else {
             var __date = new Date(Number(__json_response.data.actor.account.nrql.results[0]["latest.timestamp"]));
-            __lastUpdateTS = `'${__date.getUTCFullYear()}-${("0" + (__date.getUTCMonth() + 1)).slice(-2)}-${("0" + __date.getUTCDate()).slice(-2)}'%2C'${("0" +  __date.getUTCHours()).slice(-2)}%3A00%3A00'`;
+            __lastUpdateTS = `'${__date.getFullYear()}-${("0" + (__date.getMonth() + 1)).slice(-2)}-${("0" + __date.getDate()).slice(-2)}'%2C'${("0" +  __date.getHours()).slice(-2)}%3A00%3A00'`;
+            console.log("Last updated timestamp is: " + __lastUpdateTS);
         } //else
     } //try
     catch(_err) {


### PR DESCRIPTION
It looks like dateGenerate() generates a date/time in UTC format. The input to the method needs to be in local time zone. Documentation on it is scarce but here is the ServiceNow doc on it - https://developer.servicenow.com/dev.do#!/reference/api/orlando/server/no-namespace/c_GlideSystemScopedAPI#r_SGSYS-dateGenerate_S_S?navFilter=dateGe