### PR TITLE
matching strategy addition, remove audit logging to TDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The ```config.json``` file that is used to configure the synchronization service
 - _nr_entity_key_: An object that encapsulates the information needed to map metadaat from a New Relic Entity to a _provider_ source.
 - _nr_entity_key.type_: What type of Entity metadata will we use to reconcile the CI (attribute | tag). If _attribute_ is selected, the following _nr_entity_key.key_ value is limited to direct attributes of the Entity such as (name | accountId | guid). If _tag_ is selected the _nr_entity_key.key_ can be any value that matches a tag key possessed by the target Entity.
 - _nr_entity_key.key_: The New Relic Entity attribute that will be used to execute the resolution strategy.
-- _nr_entity_key.strategy_: How the Entity and _Provider_ key values are to be compared (caseless_match|exact_match|exact_contains|caseless_contains).
+- _nr_entity_key.strategy_: How the Entity and _Provider_ key values are to be compared (caseless_match|exact_match|exact_contains|caseless_contains|inverse_caseless_contains).
 - _nr_entity_update_: (true|false) Whether to update the Entity discovered if the Entity tag alread exists. False ignores the update if the tag exists, true updates no matter the value specified.  
 - _nr_entity_tag_key_: The New Relic Entity key value (name) for the _provider_ attribute value.
 
@@ -145,7 +145,7 @@ To encrypt sensitive fields in the config.json, execute the following proceedure
 
 ### Logging
 
-The logs section determines the location, size and max number of logs for the process. 
+The logs section determines the location, size and max number of logs for the process.
 
 ```javascript
 "logs": {

--- a/js/entitysync.js
+++ b/js/entitysync.js
@@ -37,7 +37,7 @@ async function cycleSync(_config, _logger) {
         _logger.info("Running Sync for type: " + _config.ci_types[i].type);
         __cis = await getCIArray(_config, _config.ci_types[i], _logger);
         _logger.info("CIs returned: " + __cis.length);
-        __total_cis_returned = __cis.length;
+        __total_cis_returned += __cis.length;
 
 
        //synchronization run reporting
@@ -45,7 +45,8 @@ async function cycleSync(_config, _logger) {
             "eventType": _config.nrdb_entitysync_event_name,
             "action": "ci_harvest",
             "version": _config.version,
-            "ci_cardinality": __cis.length
+            "ci_cardinality": __cis.length,
+            "ci_table": _config.ci_types[i].type
         });
 
         while(__followCursor) {
@@ -65,27 +66,27 @@ async function cycleSync(_config, _logger) {
 
                             if (__entityUpdatePayload.found) {
 
-                                //record audit message of a reconciled CI/Entity pair
-                                __auditEvent = {};
-                                __auditEvent.eventType = _config.nrdb_entitysync_event_name;
-                                __auditEvent.action = "ci_processed";
-                                __auditEvent.version = _config.version;
-                                __auditEvent.found = __entityUpdatePayload.found;
-                                __auditEvent.entity_guid = __entityUpdatePayload.entity_guid;
-                                __auditEvent.entity_name = __entityUpdatePayload.name;
-                                __auditEvent.entity_update_allowed = _config.provider.update_entity;
+                                // //record audit message of a reconciled CI/Entity pair
+                                // __auditEvent = {};
+                                // __auditEvent.eventType = _config.nrdb_entitysync_event_name;
+                                // __auditEvent.action = "ci_processed";
+                                // __auditEvent.version = _config.version;
+                                // __auditEvent.found = __entityUpdatePayload.found;
+                                // __auditEvent.entity_guid = __entityUpdatePayload.entity_guid;
+                                // __auditEvent.entity_name = __entityUpdatePayload.name;
+                                // __auditEvent.entity_update_allowed = _config.provider.update_entity;
 
-                                //add the new tags to the audit event
-                                for (var zz = 0; zz < __entityUpdatePayload.tags.length; zz++) {
-                                    _logger.verbose("tag candidate: " + __entityUpdatePayload.tags[zz].key + " with value " + __entityUpdatePayload.tags[zz].value);
-                                    __auditEvent[__entityUpdatePayload.tags[zz].key] = __entityUpdatePayload.tags[zz].value;
-                                } //for
+                                // //add the new tags to the audit event
+                                // for (var zz = 0; zz < __entityUpdatePayload.tags.length; zz++) {
+                                //     _logger.verbose("tag candidate: " + __entityUpdatePayload.tags[zz].key + " with value " + __entityUpdatePayload.tags[zz].value);
+                                //     __auditEvent[__entityUpdatePayload.tags[zz].key] = __entityUpdatePayload.tags[zz].value;
+                                // } //for
 
 
                                 if (_config.provider.update_entity === true) {
 
                                     __entityUpdateResponse = await updateEntity(_config, __entityUpdatePayload, _logger);
-                                    __auditEvent.entity_update_status = __entityUpdateResponse.message;
+                                    // __auditEvent.entity_update_status = __entityUpdateResponse.message;
 
                                     if (__entityUpdateResponse.message === "SUCCESS") {
                                         __total_entity_updates++;
@@ -104,7 +105,7 @@ async function cycleSync(_config, _logger) {
                                     __auditEvent.entity_update_status = "NO UPDATE ATTEMPT";
                                 } //else
 
-                                __reportingEvents.push(__auditEvent);
+                                // __reportingEvents.push(__auditEvent);
                                 _logger.verbose("This is the audit event: ", __auditEvent);
 
                             } //if

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -289,6 +289,16 @@ async function reconcileEntity(_ciType, _entity, _candidateCIs, _logger) {
             } //if
 
         } //else if
+        else if (_ciType.nr_entity_key.strategy === "inverse_caseless_contains") {
+
+            if (__entity_key.toUpperCase().includes(_candidateCIs[i][_ciType.key].toUpperCase())) {
+                 __entityUpdatePayload.found = true;
+                 __entityUpdatePayload.ci = _candidateCIs[i];
+                 __entityUpdatePayload.tags = await _formatAdditiveTags(_entity, _ciType, _candidateCIs[i], _logger);
+                 break;
+            } //if
+
+        } // else if
         else {
 
             _logger.info("No key matching strategy recognized, please review config.json.");
@@ -558,7 +568,7 @@ console.log("called");
 
         _logger.error("[utilities::_getServiceNowCIs] NO CIs FOUND - NO SYNC WILL HAPPEN", _err);
     } //catch
-   
+
     return(__cis);
 } //_getServiceNowCIs
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "base-64": "^1.0.0",
+    "crypto-js": "^4.1.1",
+    "express": "^4.17.1",
+    "fs": "*",
+    "https-proxy-agent": "^5.0.0",
+    "isomorphic-fetch": "^3.0.0",
+    "newrelic": "^8.3.0",
+    "node-cron": "^3.0.0",
+    "winston": "^3.3.3",
+    "winston-daily-rotate-file": "^4.5.5"
+  }
+}

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-nohup node ./js/index.js single-run
+node ./js/index.js single-run


### PR DESCRIPTION
- Added "inverse_caseless_contains" matching strategy
- Remove audit logging to Insights Endpoint - This detail can be viewed in log file instead, or be sent to Logs.
- Added "ci_table" attribute to harvest actions